### PR TITLE
Support DOTA 2.0

### DIFF
--- a/dotadevkit/cli/convert.py
+++ b/dotadevkit/cli/convert.py
@@ -14,7 +14,7 @@ def convert(src, version):
     \b
     Args:
         src (str): Source directory containing tiled images & labels
-        version (str): Dataset version (1.0, 1.5)
+        version (str): Dataset version (1.0, 1.5, 2.0)
 
     Returns:
         None

--- a/dotadevkit/cli/evaluate.py
+++ b/dotadevkit/cli/evaluate.py
@@ -18,7 +18,7 @@ def evaluate(detections, annotations, images, version, task1):
         detections (str): Merged detections directory
         annotations (str): Ground truth
         images (str): Path to text file of image names
-        version (str): DOTA version ["1.0", "1.5"]
+        version (str): DOTA version ["1.0", "1.5", "2.0"]
         task1 (bool): Task1 (Oriented BBox)
 
     Returns:

--- a/dotadevkit/evaluate/task1.py
+++ b/dotadevkit/evaluate/task1.py
@@ -28,7 +28,7 @@ def parse_gt(filename, version):
                     continue
                 object_struct["name"] = splitlines[8]
 
-                if version == "1.5":
+                if version in ["1.5", "2.0"]:
                     # DOTA 1.5 includes difficult annotations
                     # by setting all annotations as easy
                     object_struct["difficult"] = 0
@@ -245,10 +245,12 @@ def voc_eval(
 
 
 def evaluate(detpath, annopath, imagesetfile, version="1.0"):
-    assert version in ["1.0", "1.5"]
+    assert version in ["1.0", "1.5", "2.0"]
     classnames = dota_classes
     if version == "1.5":
         classnames = classnames + ["container-crane"]
+    if version == "2.0":
+        classnames = classnames + ["container-crane", "airport", "helipad"]
 
     classaps = []
     map = 0

--- a/dotadevkit/evaluate/task2.py
+++ b/dotadevkit/evaluate/task2.py
@@ -20,7 +20,7 @@ def parse_gt(filename, version):
                 continue
             object_struct["name"] = splitline[8]
 
-            if version == "1.5":
+            if version in ["1.5", "2.0"]:
                 # DOTA 1.5 includes difficult annotations
                 # by setting all annotations as easy
                 object_struct["difficult"] = 0
@@ -201,10 +201,12 @@ def voc_eval(
 
 
 def evaluate(detpath, annopath, imagesetfile, version="1.0"):
-    assert version in ["1.0", "1.5"]
+    assert version in ["1.0", "1.5", "2.0"]
     classnames = dota_classes
     if version == "1.5":
         classnames = classnames + ["container-crane"]
+    if version == "2.0":
+        classnames = classnames + ["container-crane", "airport", "helipad"]
 
     classaps = []
     map = 0

--- a/dotadevkit/ops/CocoConvert.py
+++ b/dotadevkit/ops/CocoConvert.py
@@ -9,26 +9,24 @@ import json
 from dotadevkit.misc.dota_utils import dota_classes, parse_dota_poly2
 from pathlib import Path
 
-website_links = {
-    "1.0": "https://captain-whu.github.io/DOTA/",
-    "1.5": "https://captain-whu.github.io/DOAI2019/dataset.html",
-}
-
 
 def DOTA2COCO(srcpath, destfile, version="1.0"):
     imageparent = srcpath / "images"
     labelparent = srcpath / "labelTxt"
-    assert version in ["1.0", "1.5"]
+    assert version in ["1.0", "1.5", "2.0"]
 
-    if version == 1.5:
+    if version == "1.5":
         dota_classes.append("container-crane")
+
+    if version == "2.0":
+        dota_classes.extend(["container-crane", "airport", "helipad"])
 
     data_dict = {}
     info = {
         "contributor": "Captain Group, Wuhan University",
         "data_created": "2018",
         "description": f"DOTA dataset version {version}",
-        "url": website_links[version],
+        "url": "https://captain-whu.github.io/DOTA/dataset.html",
         "version": version,
         "year": 2018,
     }


### PR DESCRIPTION
Closes #14 

Note: DOTA 1.5 included difficult examples during evaluation as opposed to DOTA 1.0. This commit assumes that DOTA 2.0 follows the 1.5 evaluation rule.